### PR TITLE
Cap maximum lureSpeed to prevent endless loop.

### DIFF
--- a/src/main/java/com/teammetallurgy/aquaculture/item/AquaFishingRodItem.java
+++ b/src/main/java/com/teammetallurgy/aquaculture/item/AquaFishingRodItem.java
@@ -88,6 +88,7 @@ public class AquaFishingRodItem extends FishingRodItem {
                 if (!isAdminRod && !bait.isEmpty()) {
                     lureSpeed += ((BaitItem) bait.getItem()).getLureSpeedModifier();
                 }
+                lureSpeed = Math.min(5, lureSpeed);
                 //Luck
                 int luck = EnchantmentHelper.getFishingLuckBonus(heldStack);
                 if (hook != Hooks.EMPTY && hook.getLuckModifier() > 0) luck += hook.getLuckModifier();


### PR DESCRIPTION
If lureSpeed is somehow greater than 5 (eg. Apotheosis provides the Lure IV enchant, which when combined with Neptunium + bait = 6), the bobber will constantly update ticksCaughtDelay each tick instead of successfully catching anything. This should be capped at a maximum of five to prevent that endless loop.