### PR TITLE
[AquaCulture] Added a json for intermod compatibility

### DIFF
--- a/src/main/resources/assets/aquaculture/load_screens/pga_compat.json
+++ b/src/main/resources/assets/aquaculture/load_screens/pga_compat.json
@@ -1,0 +1,8 @@
+{
+	"screens" : [{
+			"COMMENT" : "Public Gui Announcement support", 
+			"class" : "com.teammetallurgy.aquaculture.inventory.container.TackleBoxContainer", 
+			"texture" : "aquaculture:textures/gui/container/tackle_box.png",
+			"size" : [175,171]
+		}]
+}


### PR DESCRIPTION
the PGA :
https://www.curseforge.com/minecraft/mc-mods/public-gui-announcement

The Wiki on how these JSON files work :
https://github.com/ArtixAllMighty/PublicGuiAnnouncement/wiki/Add-Mod-Compatibility

In this PR is contained one json file to add compatibility with the mod Public Gui Announcement.
I wanted to ship the compat at first with my mod, but it would be better if the author maintains it himself. (in case of path and name changes as well addition or removal from screens).

I hereby give you all files needed to add compatibility to my mod. There is nothing else left to do apart from merging the PR.

If you have any other question, I'd be happy to answer !