### PR TITLE
Adjust duration of effects to prevent flickering.

### DIFF
--- a/src/main/java/com/teammetallurgy/aquaculture/item/neptunium/NeptuniumArmor.java
+++ b/src/main/java/com/teammetallurgy/aquaculture/item/neptunium/NeptuniumArmor.java
@@ -27,15 +27,15 @@ public class NeptuniumArmor extends ArmorItem {
     public void onArmorTick(@Nonnull ItemStack stack, World world, PlayerEntity player) {
         if (player.areEyesInFluid(FluidTags.WATER)) {
             if (this.slot == EquipmentSlotType.HEAD) {
-                player.addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 1, 0, false, false, false));
+                player.addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 60, 0, false, false, false));
             } else if (this.slot == EquipmentSlotType.CHEST) {
-                player.addPotionEffect(new EffectInstance(Effects.WATER_BREATHING, 1, 0, false, false, false));
+                player.addPotionEffect(new EffectInstance(Effects.WATER_BREATHING, 60, 0, false, false, false));
             } else if (this.slot == EquipmentSlotType.LEGS) {
                 if (!player.isCrouching()) {
                     player.setMotion(player.getMotion().add(0, player.fallDistance, 0));
                 }
             } else if (this.slot == EquipmentSlotType.FEET) {
-                player.addPotionEffect(new EffectInstance(Effects.SPEED, 1, 0, false, false, false));
+                player.addPotionEffect(new EffectInstance(Effects.SPEED, 60, 0, false, false, false));
                 player.move(MoverType.PLAYER, player.getMotion()); //Make the swimming react to the swiftness potion
             }
         }

--- a/src/main/java/com/teammetallurgy/aquaculture/item/neptunium/NeptuniumArmor.java
+++ b/src/main/java/com/teammetallurgy/aquaculture/item/neptunium/NeptuniumArmor.java
@@ -27,15 +27,15 @@ public class NeptuniumArmor extends ArmorItem {
     public void onArmorTick(@Nonnull ItemStack stack, World world, PlayerEntity player) {
         if (player.areEyesInFluid(FluidTags.WATER)) {
             if (this.slot == EquipmentSlotType.HEAD) {
-                player.addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 60, 0, false, false, false));
+                player.addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 20, 0, false, false, false));
             } else if (this.slot == EquipmentSlotType.CHEST) {
-                player.addPotionEffect(new EffectInstance(Effects.WATER_BREATHING, 60, 0, false, false, false));
+                player.addPotionEffect(new EffectInstance(Effects.WATER_BREATHING, 20, 0, false, false, false));
             } else if (this.slot == EquipmentSlotType.LEGS) {
                 if (!player.isCrouching()) {
                     player.setMotion(player.getMotion().add(0, player.fallDistance, 0));
                 }
             } else if (this.slot == EquipmentSlotType.FEET) {
-                player.addPotionEffect(new EffectInstance(Effects.SPEED, 60, 0, false, false, false));
+                player.addPotionEffect(new EffectInstance(Effects.SPEED, 20, 0, false, false, false));
                 player.move(MoverType.PLAYER, player.getMotion()); //Make the swimming react to the swiftness potion
             }
         }


### PR DESCRIPTION
Neptunium Armour effects (notably Night Vision) cause flickering with some shaders, as the effect rapidly toggles on and off with a duration of one tick. Bumping this up slightly shouldn't impact gameplay too much (as it will only linger briefly after leaving the water) but will prevent the visual flickering.

Note: This should probably be merged into both 1.15 and 1.14.4 branches.