### PR TITLE
Reduced Neptune's Bounty drop weight

### DIFF
--- a/src/main/resources/data/aquaculture/loot_tables/gameplay/fishing/neptunium.json
+++ b/src/main/resources/data/aquaculture/loot_tables/gameplay/fishing/neptunium.json
@@ -4,6 +4,7 @@
   "pools": [
     {
       "rolls": 1.0,
+      "weight": 1,
       "entries": [
         {
           "type": "minecraft:item",


### PR DESCRIPTION
ignore if methodology is incorrect. Looking to reduce drop rate of Neptune's Bounty. In testing getting 30 chests per hour of fishing. With afk fishing being very popular, it means everyone has 100s to 1000s of chests after a couple days. Added weight modifier to line 7 of code, if incorrect maybe add a config line in the default config file instead?