### PR TITLE
Add recipe unlocks for the Recipe Book

### DIFF
--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/bobber.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/bobber.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:bobber"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:tackle_box"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:bobber"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/diamond_hook.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/diamond_hook.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:diamond_hook"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:diamond_hook"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/double_hook.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/double_hook.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:double_hook"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:double_hook"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/fishing_line.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/fishing_line.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:fishing_line"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:tackle_box"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:fishing_line"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/gold_hook.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/gold_hook.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:gold_hook"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:gold_hook"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_alt_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/heavy_hook.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/heavy_hook.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:heavy_hook"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:heavy_hook"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/iron_hook.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/iron_hook.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:iron_hook"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:tackle_box"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:iron_hook"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/light_hook.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/light_hook.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:light_hook"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:light_hook"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/neptunes_bounty.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/neptunes_bounty.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunes_bounty"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunes_bounty"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/nether_star_hook.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/nether_star_hook.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:bobber"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:nether_stars"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:bobber"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/note_hook.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/note_hook.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:note_hook"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:note_hook"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/redstone_hook.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/redstone_hook.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:redstone_hook"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:redstone_hook"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/tackle_box.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/tackle_box.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:tackle_box"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "aquaculture:tackle_box_green"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:tackle_box"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/worm_farm.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/aquaculture/worm_farm.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:worm_farm"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:tackle_box"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:worm_farm"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/building_blocks/planks_from_driftwood.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/building_blocks/planks_from_driftwood.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:planks_from_driftwood"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:driftwood"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:planks_from_driftwood"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_boots.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_boots.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_boots"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_boots"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_armor_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_bow.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_bow.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_bow"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_bow"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_chestplate.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_chestplate.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_chestplate"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_chestplate"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_armor_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_helmet.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_helmet.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_helmet"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_helmet"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_armor_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_leggings.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_leggings.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_leggings"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_leggings"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_armor_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_sword.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/combat/neptunium_sword.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_sword"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_sword"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/decorations/acacia_fish_mount.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/decorations/acacia_fish_mount.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:acacia_fish_mount"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:acacia_fish_mount"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/decorations/birch_fish_mount.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/decorations/birch_fish_mount.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:birch_fish_mount"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:birch_fish_mount"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/decorations/dark_oak_fish_mount.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/decorations/dark_oak_fish_mount.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:dark_oak_fish_mount"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:dark_oak_fish_mount"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/decorations/jungle_fish_mount.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/decorations/jungle_fish_mount.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:jungle_fish_mount"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:jungle_fish_mount"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/decorations/oak_fish_mount.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/decorations/oak_fish_mount.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:oak_fish_mount"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:oak_fish_mount"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/decorations/spruce_fish_mount.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/decorations/spruce_fish_mount.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:spruce_fish_mount"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_hook"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:spruce_fish_mount"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_fish_fillet.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_fish_fillet.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:cooked_fish_fillet"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:fish_fillet_raw"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:cooked_fish_fillet"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_fish_fillet_from_campfire.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_fish_fillet_from_campfire.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:cooked_fish_fillet_from_campfire"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:fish_fillet_raw"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:cooked_fish_fillet_from_campfire"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_fish_fillet_from_smoking.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_fish_fillet_from_smoking.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:cooked_fish_fillet_from_smoking"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:fish_fillet_raw"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:cooked_fish_fillet_from_smoking"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_frog_legs.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_frog_legs.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:cooked_frog_legs"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:frog_legs_raw"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:cooked_frog_legs"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_frog_legs_from_campfire.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_frog_legs_from_campfire.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:cooked_frog_legs_from_campfire"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:frog_legs_raw"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:cooked_frog_legs_from_campfire"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_frog_legs_from_smoking.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/food/cooked_frog_legs_from_smoking.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:cooked_frog_legs_from_smoking"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:frog_legs_raw"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:cooked_frog_legs_from_smoking"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/food/frog_legs.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/food/frog_legs.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:frog_legs"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:frog"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:frog_legs"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/food/sushi.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/food/sushi.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:sushi"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:fish_fillet_raw"
+          }
+        ]
+      }
+    },
+    "has_alt_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:seagrass"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:sushi"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_alt_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/food/turtle_soup.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/food/turtle_soup.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:turtle_soup"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "aquaculture:turtle"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:turtle_soup"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/bonemeal_from_fish_bones.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/bonemeal_from_fish_bones.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:bonemeal_from_fish_bones"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:fish_bones"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:bonemeal_from_fish_bones"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/brown_mushroom_from_fish.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/brown_mushroom_from_fish.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:brown_mushroom_from_fish"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:brown_shrooma"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:brown_mushroom_from_fish"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/gold_nugget_from_blasting.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/gold_nugget_from_blasting.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:gold_nugget_from_blasting"
+    ]
+  },
+  "criteria": {
+    "has_fishing_rod": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:gold_fishing_rod"
+          }
+        ]
+      }
+    },
+    "has_fillet_knife": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:gold_fillet_knife"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:gold_nugget_from_blasting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_fishing_rod",
+      "has_fillet_knife",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/gold_nugget_from_gold_fish.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/gold_nugget_from_gold_fish.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            "item": "aquaculture:goldfish
+            "item": "aquaculture:goldfish"
           }
         ]
       }

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/gold_nugget_from_gold_fish.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/gold_nugget_from_gold_fish.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:gold_nugget_from_gold_fish"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:goldfish
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:gold_nugget_from_gold_fish"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/gold_nugget_from_smelting.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/gold_nugget_from_smelting.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:gold_nugget_from_smelting"
+    ]
+  },
+  "criteria": {
+    "has_fishing_rod": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:gold_fishing_rod"
+          }
+        ]
+      }
+    },
+    "has_fillet_knife": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:gold_fillet_knife"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:gold_nugget_from_smelting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_fishing_rod",
+      "has_fillet_knife",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/iron_nugget_from_blasting.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/iron_nugget_from_blasting.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:iron_nugget_from_blasting"
+    ]
+  },
+  "criteria": {
+    "has_fishing_rod": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_fishing_rod"
+          }
+        ]
+      }
+    },
+    "has_fillet_knife": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_fillet_knife"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:iron_nugget_from_blasting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_fishing_rod",
+      "has_fillet_knife",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/iron_nugget_from_smelting.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/iron_nugget_from_smelting.json
@@ -1,0 +1,43 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:iron_nugget_from_smelting"
+    ]
+  },
+  "criteria": {
+    "has_fishing_rod": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_fishing_rod"
+          }
+        ]
+      }
+    },
+    "has_fillet_knife": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:iron_fillet_knife"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:iron_nugget_from_smelting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_fishing_rod",
+      "has_fillet_knife",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/jellyfish_to_slimeball.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/jellyfish_to_slimeball.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:jellyfish_to_slimeball"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:jellyfish"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:jellyfish_to_slimeball"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/neptinium_ingot_from_blasting.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/neptinium_ingot_from_blasting.json
@@ -1,0 +1,153 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptinium_ingot_from_blasting"
+    ]
+  },
+  "criteria": {
+    "has_axe": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_axe"
+          }
+        ]
+      }
+    },
+    "has_boots": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_boots"
+          }
+        ]
+      }
+    },
+    "has_chestplate": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_chestplate"
+          }
+        ]
+      }
+    },
+    "has_fillet_knife": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_fillet_knife"
+          }
+        ]
+      }
+    },
+    "has_fishing_rod": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_fishing_rod"
+          }
+        ]
+      }
+    },
+    "has_helmet": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_helmet"
+          }
+        ]
+      }
+    },
+    "has_hoe": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_hoe"
+          }
+        ]
+      }
+    },
+    "has_leggings": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_leggings"
+          }
+        ]
+      }
+    },
+    "has_pickaxe": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_pickaxe"
+          }
+        ]
+      }
+    },
+    "has_shovel": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_shovel"
+          }
+        ]
+      }
+    },
+    "has_sword": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_sword"
+          }
+        ]
+      }
+    },
+    "has_bow": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_bow"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptinium_ingot_blasting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_axe",
+      "has_boots",
+      "has_chestplate",
+      "has_fillet_knife",
+      "has_fishing_rod",
+      "has_helmet",
+      "has_hoe",
+      "has_leggings",
+      "has_pickaxe",
+      "has_shovel",
+      "has_sword",
+      "has_bow",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/neptunium_ingot_from_neptunium_block.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/neptunium_ingot_from_neptunium_block.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_ingot_from_neptunium_block"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_block"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_ingot_from_neptunium_block"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/neptunium_ingot_from_nuggets.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/neptunium_ingot_from_nuggets.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_ingot_from_nuggets"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:neptunium_nugget"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_ingot_from_nuggets"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/red_mushroom_from_fish.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/red_mushroom_from_fish.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:red_mushroom_from_fish"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:red_shrooma"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:red_mushroom_from_fish"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/tin_can_to_iron_nugget.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/tin_can_to_iron_nugget.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:tin_can_to_iron_nugget"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:tin_can"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:tin_can_to_iron_nugget"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/misc/tin_can_to_iron_nugget_from_blasting.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/misc/tin_can_to_iron_nugget_from_blasting.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:tin_can_to_iron_nugget_from_blasting"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "aquaculture:tin_can"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:tin_can_to_iron_nugget_from_blasting"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/diamond_fillet_knife.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/diamond_fillet_knife.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:diamond_fillet_knife"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:gems/diamond"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:diamond_fillet_knife"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/diamond_fishing_rod.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/diamond_fishing_rod.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:diamond_fishing_rod"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:gems/diamond"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:diamond_fishing_rod"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/diamond_fishing_rod.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/diamond_fishing_rod.json
@@ -16,7 +16,6 @@
         ]
       }
     },
-   "criteria": {
     "has_vanilla_rod": {
       "trigger": "minecraft:inventory_changed",
       "conditions": {

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/diamond_fishing_rod.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/diamond_fishing_rod.json
@@ -6,12 +6,23 @@
     ]
   },
   "criteria": {
-    "has_items": {
+    "has_diamond": {
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
           {
             "tag": "forge:gems/diamond"
+          }
+        ]
+      }
+    },
+   "criteria": {
+    "has_vanilla_rod": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:fishing_rod"
           }
         ]
       }
@@ -25,7 +36,8 @@
   },
   "requirements": [
     [
-      "has_items",
+      "has_diamond",
+      "has_vanilla_rod",
       "has_the_recipe"
     ]
   ]

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/gold_fillet_knife.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/gold_fillet_knife.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:gold_fillet_knife"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/gold"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:gold_fillet_knife"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/golden_fishing_rod.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/golden_fishing_rod.json
@@ -6,12 +6,22 @@
     ]
   },
   "criteria": {
-    "has_items": {
+    "has_gold": {
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
           {
             "tag": "forge:ingots/gold"
+          }
+        ]
+      }
+    },
+    "has_vanilla_rod": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:fishing_rod"
           }
         ]
       }
@@ -25,7 +35,8 @@
   },
   "requirements": [
     [
-      "has_items",
+      "has_gold",
+      "has_vanilla_rod",
       "has_the_recipe"
     ]
   ]

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/golden_fishing_rod.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/golden_fishing_rod.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:golden_fishing_rod"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/gold"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:golden_fishing_rod"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/iron_fillet_knife.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/iron_fillet_knife.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:iron_fillet_knife"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/iron"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:iron_fillet_knife"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/iron_fishing_rod.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/iron_fishing_rod.json
@@ -6,12 +6,22 @@
     ]
   },
   "criteria": {
-    "has_items": {
+    "has_iron": {
       "trigger": "minecraft:inventory_changed",
       "conditions": {
         "items": [
           {
             "tag": "forge:ingots/iron"
+          }
+        ]
+      }
+    },
+    "has_vanilla_rod": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "item": "minecraft:fishing_rod"
           }
         ]
       }
@@ -25,7 +35,8 @@
   },
   "requirements": [
     [
-      "has_items",
+      "has_iron",
+      "has_vanilla_rod",
       "has_the_recipe"
     ]
   ]

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/iron_fishing_rod.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/iron_fishing_rod.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:iron_fishing_rod"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/iron"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:iron_fishing_rod"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_axe.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_axe.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_axe"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_axe"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_fillet_knife.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_fillet_knife.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_fillet_knife"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_fillet_knife"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_fishing_rod.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_fishing_rod.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_fishing_rod"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_fishing_rod"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_hoe.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_hoe.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_hoe"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_hoe"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_pickaxe.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_pickaxe.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_pickaxe"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_pickaxe"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_shovel.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/neptunium_shovel.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:neptunium_shovel"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:ingots/neptunium"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:neptunium_shovel"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/stone_fillet_knife.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/stone_fillet_knife.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:stone_fillet_knife"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:cobblestone"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:stone_fillet_knife"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}

--- a/src/main/resources/data/aquaculture/advancements/recipes/tools/wooden_fillet_knife.json
+++ b/src/main/resources/data/aquaculture/advancements/recipes/tools/wooden_fillet_knife.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "rewards": {
+    "recipes": [
+      "aquaculture:wooden_fillet_knife"
+    ]
+  },
+  "criteria": {
+    "has_items": {
+      "trigger": "minecraft:inventory_changed",
+      "conditions": {
+        "items": [
+          {
+            "tag": "forge:rods/wooden"
+          }
+        ]
+      }
+    },
+    "has_the_recipe": {
+      "trigger": "minecraft:recipe_unlocked",
+      "conditions": {
+        "recipe": "aquaculture:wooden_fillet_knife"
+      }
+    }
+  },
+  "requirements": [
+    [
+      "has_items",
+      "has_the_recipe"
+    ]
+  ],
+    "conditions": [{"type":"aquaculture:neptunium_items_enabled","value":true}]
+}


### PR DESCRIPTION
Add advancemetns to unlock recipes in the recipe book. If you disagree with the choices I made for some recipes, feel free to change them:
Tackle Box - unlocks when you obtain any item with an "aquaculture:tackle_box_green" tag
Iron Hook, Bobber, Fishing Line, Worm Farm - unlock when you obtain the Tackle Box
Other Hooks (Except Nether Star) and Fish Mounts - unlock when you obtain an Iron Hook
Nether Star Hook - when you obtain an item with a "forge:nether_stars" tag
Gold/Iron Fillet Knife/Fishing Rod - when you obtain an item with a "forge:ingots/gold" or "forge:ingots/iron" tag respectively
Neptunium items - if you have an item with a "forge:ingots/neptunium" tag and the respective config is enabled