### PR TITLE
AquaFishingRodItem Material Getter

### DIFF
--- a/src/main/java/com/teammetallurgy/aquaculture/item/AquaFishingRodItem.java
+++ b/src/main/java/com/teammetallurgy/aquaculture/item/AquaFishingRodItem.java
@@ -40,6 +40,10 @@ public class AquaFishingRodItem extends FishingRodItem {
         this.material = material;
     }
 
+    public IItemTier getItemMaterial() {
+        return material;
+    }
+
     @Override
     public int getItemEnchantability() {
         return enchantability;


### PR DESCRIPTION
Use of the Aquaculture fishing rod in a Minecolonies Fisherman hut relies on being able to assign tiers to the different rods. Access to the material used allows this to be done directly without needing to perform Forge item registry lookups and comparisons.