### PR TITLE
Clarify readme for Gradle setup of Aquaculture vs Aquaculture2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An expansion of Minecraft's fishing system. You never know what you'll catch. Every biome is home to tons of unique fish you can only catch in that biome, and there's a myriad of new loot items you can randomly catch while fishing.
 
-How to get Aquaculture through maven
+How to get Aquaculture (1.12) through maven
 ---
 Add to your build.gradle:
 ```gradle
@@ -16,6 +16,23 @@ repositories {
 dependencies {
   // compile against Aquaculture
   compile fg.deobf("com.teammetallurgy.aquaculture:aquaculture_${mc_version}:${mc_version}-${aquaculture_version}")
+}
+```
+
+How to get Aquaculture2 (1.14-1.16.x) through maven
+---
+Add to your build.gradle:
+```gradle
+repositories {
+  maven {
+    // url of the maven that hosts Aquacultures files
+    url "http://girafi.dk/maven/"
+  }
+}
+
+dependencies {
+  // compile against Aquaculture 2
+  compile fg.deobf("com.teammetallurgy.aquaculture:aquaculture2_${mc_version}:${mc_version}-${aquaculture_version}")
 }
 ```
 


### PR DESCRIPTION
Sorry, this is probably a really obvious thing for more experienced modders, but I managed to spend an hour doing it wrong.  Just adds a second line to readme.md, since the maven config info is subtly different between the two versions.

There's probably a smarter way to do it programmatically, but I don't want to end up breaking things again.