### PR TITLE
Switch fillet_knives over to universal Forge tag

### DIFF
--- a/src/main/java/com/teammetallurgy/aquaculture/api/AquacultureAPI.java
+++ b/src/main/java/com/teammetallurgy/aquaculture/api/AquacultureAPI.java
@@ -35,7 +35,7 @@ public class AquacultureAPI {
     }
 
     public static class Tags {
-        public static final TagKey<Item> FILLET_KNIFE = tag("forge", "fillet_knife");
+        public static final TagKey<Item> FILLET_KNIFE = tag("forge", "forge:tools/knives");
         public static final TagKey<Item> FISHING_LINE = tag(Aquaculture.MOD_ID, "fishing_line");
         public static final TagKey<Item> BOBBER = tag(Aquaculture.MOD_ID, "bobber");
         public static final TagKey<Item> TACKLE_BOX = tag(Aquaculture.MOD_ID, "tackle_box");

--- a/src/main/resources/data/forge/tags/items/tools/knives.json
+++ b/src/main/resources/data/forge/tags/items/tools/knives.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:fillet_knife"
+  ]
+}


### PR DESCRIPTION
Many mods reference the tag "forge:tools/knives" for their recipes involving Knife items.
This PR adds Aquaculture's knives to this tag.
It also changes Aquaculture's recipes to use the universal tag, allowing them to be compatible with any Knife.