### PR TITLE
Fix NoSuchElementException when retrieving entity-hooked bobber (#547)

### DIFF
--- a/src/main/java/com/teammetallurgy/aquaculture/entity/AquaFishingBobberEntity.java
+++ b/src/main/java/com/teammetallurgy/aquaculture/entity/AquaFishingBobberEntity.java
@@ -191,7 +191,7 @@ public class AquaFishingBobberEntity extends FishingHook implements IEntityWithC
     }
 
     public void triggerFishingRodHooked(ServerPlayer angler, @Nonnull ItemStack stack, List<ItemStack> lootEntries) {
-        if (lootEntries.getFirst().getItem() instanceof FishItem) {
+        if (!lootEntries.isEmpty() && lootEntries.getFirst().getItem() instanceof FishItem) {
             CriteriaTriggers.FISHING_ROD_HOOKED.trigger(angler, stack, this, List.of(new ItemStack(Items.COD))); //Used to trigger Fishy Business advancement for AQ fish
         } else {
             CriteriaTriggers.FISHING_ROD_HOOKED.trigger(angler, stack, this, lootEntries);


### PR DESCRIPTION
 Hi, I've been playing Aquaculture 2 on 1.21.1 recently and ran into the issue reported in #547.

  When the bobber hooks an entity, `retrieve()` ends up calling `triggerFishingRodHooked(..., Collections.emptyList())`.
  That method then calls `lootEntries.getFirst()` without checking whether the list is empty, which throws a
  `NoSuchElementException`. Because of that, `retrieve()` is interrupted before the bobber can be discarded, so the hook
  gets stuck.

  I wanted to help fix it, so I made a small change here: the fish-item advancement check now first verifies that
  `lootEntries` is not empty before accessing the first element.

  With this change, entity-hook retrieval no longer crashes, the vanilla trigger still runs with the empty list, and the
  bobber is properly discarded afterward.