### PR TITLE
Remove FishingReal datapack file that will cause a compat issue.

### DIFF
--- a/src/main/resources/data/fishingreal/fishing/combustive_cod.json
+++ b/src/main/resources/data/fishingreal/fishing/combustive_cod.json
@@ -1,8 +1,0 @@
-{
-    "input": {
-        "item": "combustivefishing:combustive_cod"
-    },
-    "result": {
-        "id": "combustivefishing:combustive_cod"
-    }
-}


### PR DESCRIPTION
Currently porting Fishing Real, and noticed that in #488 I accidentally PR'd combustive cod from the Combustive Fishing mod into the datapack.

Due to the nature of the internal changes to minecraft updating from 1.21 -> 26.1, I'm having to rewrite the datapack portion of Fishing Real. In doing so, the datapack will now cause an error during world load if the `RegistryKey` doesn't exist. (Same error if setting a villager trade to an item that doesn't exist, but I digress...)